### PR TITLE
Allow multiples of cookies with different domains

### DIFF
--- a/jar.js
+++ b/jar.js
@@ -30,7 +30,7 @@ var CookieJar = exports = module.exports = function CookieJar() {
 CookieJar.prototype.add = function(cookie){
   this.cookies = this.cookies.filter(function(c){
     // Avoid duplication (same path, same name)
-    return !(c.name == cookie.name && c.path == cookie.path);
+    return !(c.name == cookie.name && c.path == cookie.path && c.domain == cookie.domain);
   });
   this.cookies.push(cookie);
 };


### PR DESCRIPTION
I'm currently working with a site right now that returns cookies with the same name, but different domains set (one blank and one with the www stripped off).  One of them has data I need, but isn't included because its name and path match the other.
