### PR TITLE
Use domain for filtering cookies, when available

### DIFF
--- a/jar.js
+++ b/jar.js
@@ -44,13 +44,21 @@ CookieJar.prototype.add = function(cookie){
 */
 
 CookieJar.prototype.get = function(req){
-  var path = url.parse(req.url).pathname
+  var parsedUrl = url.parse(req.url)
+    , path = parsedUrl.pathname
+    , host = parsedUrl.hostname
     , now = new Date
     , specificity = {};
   return this.cookies.filter(function(cookie){
-    if (0 == path.indexOf(cookie.path) && now < cookie.expires
-      && cookie.path.length > (specificity[cookie.name] || 0))
-      return specificity[cookie.name] = cookie.path.length;
+    if (0 == path.indexOf(cookie.path) && now < cookie.expires &&
+        cookie.path.length > (specificity[cookie.name] || 0))
+    {
+      if (cookie.domain) {
+        if (host.indexOf(cookie.domain) !== -1 && (host.length - cookie.domain.length) == host.indexOf(cookie.domain)) {
+          return specificity[cookie.name] = cookie.path.length;
+        } else return false
+      } else return specificity[cookie.name] = cookie.path.length;
+    }
   });
 };
 

--- a/tests/test-cookiejar.js
+++ b/tests/test-cookiejar.js
@@ -83,6 +83,26 @@ function expires(ms) {
   var cookies = jar.get({ url: 'http://foo.com/' });
   assert.equal(cookies.length, 1);
   assert.equal(cookies[0], e);
+
+  // .get with domain
+  var jar = new Jar;
+  var a = new Cookie('sid=1234; path=/; domain=localhost');
+  var b = new Cookie('sid=1111; path=/foo/bar; domain=example.com');
+  var c = new Cookie('sid=2222; path=/baz; domain=www.site.com');
+  jar.add(a);
+  jar.add(b);
+  jar.add(c);
+
+  var cookie = jar.get({url: 'http://localhost:8000/foo'})
+  assert.equal(cookie.length, 1);
+  assert.equal(cookie[0], a);
+
+  var cookie = jar.get({url: 'http://www.example.com/foo/bar/baz'})
+  assert.equal(cookie.length, 1);
+  assert.equal(cookie[0], b);
+
+  var cookie = jar.get({url: 'http://site.com/baz'})
+  assert.equal(cookie.length, 0);
 })();
 
 setTimeout(function() {


### PR DESCRIPTION
`CookieJar#get` will apply additional filtering when cookies contain `domain` property to only return cookies suitable for provided `url`.
